### PR TITLE
feat(door43): minimal API client — version/health (#4)

### DIFF
--- a/packages/door43/README.md
+++ b/packages/door43/README.md
@@ -1,3 +1,15 @@
 # `@biblia-studio/door43`
 
-HTTP client surfaces and types for **Door43**. Follow the [Door43 API developer guide](https://github.com/unfoldingWord/uW-Tools-Collab) and live [Swagger](https://git.door43.org/api/swagger).
+HTTP client surfaces and types for **Door43** ([Gitea](https://git.door43.org/)). Follow the [Door43 API developer guide](https://github.com/unfoldingWord/uW-Tools-Collab) and live [Swagger](https://git.door43.org/api/swagger).
+
+## Public API (no auth)
+
+The Gitea **`GET /api/v1/version`** endpoint is callable without authentication. Use `fetchDoor43Version()` to hit `https://<host>/api/v1/version` (default host: `git.door43.org`).
+
+```ts
+import { fetchDoor43Version } from "@biblia-studio/door43";
+
+const { version } = await fetchDoor43Version();
+```
+
+Auth, tokens, and private resources are out of scope for this slice; see Swagger for endpoints that require login.

--- a/packages/door43/src/constants.ts
+++ b/packages/door43/src/constants.ts
@@ -1,0 +1,2 @@
+/** Default Gitea host for Door43 (HTTPS). */
+export const DOOR43_HOST_DEFAULT = "git.door43.org" as const;

--- a/packages/door43/src/index.ts
+++ b/packages/door43/src/index.ts
@@ -4,4 +4,5 @@
  */
 export { BIBLIA_STUDIO } from "@biblia-studio/core";
 
-export const DOOR43_HOST_DEFAULT = "git.door43.org" as const;
+export { DOOR43_HOST_DEFAULT } from "./constants.js";
+export { fetchDoor43Version, type Door43VersionResponse } from "./version.js";

--- a/packages/door43/src/version.test.ts
+++ b/packages/door43/src/version.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchDoor43Version } from "./version.js";
+
+describe("fetchDoor43Version", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests /api/v1/version on the default host and returns version", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.21.0" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchDoor43Version();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://git.door43.org/api/v1/version",
+    );
+    expect(result).toEqual({ version: "1.21.0" });
+  });
+
+  it("uses a custom host when provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "9.9.9" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchDoor43Version({ host: "example.org" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.org/api/v1/version",
+    );
+  });
+
+  it("throws when response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      }),
+    );
+
+    await expect(fetchDoor43Version()).rejects.toThrow(
+      "Door43 API 503: Service Unavailable",
+    );
+  });
+
+  it("throws when version is missing from JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(fetchDoor43Version()).rejects.toThrow(
+      "Invalid Door43 version response",
+    );
+  });
+});

--- a/packages/door43/src/version.ts
+++ b/packages/door43/src/version.ts
@@ -1,0 +1,25 @@
+import { DOOR43_HOST_DEFAULT } from "./constants.js";
+
+export type Door43VersionResponse = {
+  version: string;
+};
+
+/**
+ * Calls the public Gitea endpoint `GET /api/v1/version` (no auth).
+ * @see https://git.door43.org/api/swagger
+ */
+export async function fetchDoor43Version(options?: {
+  host?: string;
+}): Promise<Door43VersionResponse> {
+  const host = options?.host ?? DOOR43_HOST_DEFAULT;
+  const url = `https://${host}/api/v1/version`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Door43 API ${res.status}: ${res.statusText}`);
+  }
+  const data = (await res.json()) as { version?: unknown };
+  if (typeof data.version !== "string") {
+    throw new Error("Invalid Door43 version response: missing version string");
+  }
+  return { version: data.version };
+}


### PR DESCRIPTION
## Summary

Implements the first Door43 integration slice from #4: typed `fetchDoor43Version()` calling public `GET /api/v1/version`, with Vitest (mocked `fetch`) and README updates.

## Changes

- `fetchDoor43Version({ host? })` → `{ version }` from JSON
- `DOOR43_HOST_DEFAULT` moved to `constants.ts` for clean module graph
- Tests: default URL, custom host, non-OK response, invalid JSON

Closes #4