### PR TITLE
feat(web): M1 Door43 repo search + /door43 page (#8)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,5 +1,7 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/create-next-app).
 
+`dev` / `build` use **`--webpack`** so the workspace package `@biblia-studio/door43` (NodeNext-style `.js` imports to `.ts` sources) resolves correctly. See `next.config.js` (`transpilePackages`, `resolve.extensionAlias`).
+
 ## Getting Started
 
 First, run the development server:

--- a/apps/web/app/door43/page.tsx
+++ b/apps/web/app/door43/page.tsx
@@ -1,0 +1,42 @@
+import { DOOR43_REPO_SEARCH_DEFAULT_QUERY } from "@biblia-studio/door43";
+import Link from "next/link";
+import { createDoor43ReposAdapter } from "../../src/adapters/driven/door43-repos.adapter";
+
+export const dynamic = "force-dynamic";
+
+export default async function Door43Page() {
+  const port = createDoor43ReposAdapter();
+  const repos = await port.searchPublicRepos({
+    query: DOOR43_REPO_SEARCH_DEFAULT_QUERY,
+    limit: 15,
+  });
+
+  return (
+    <main style={{ padding: "1.5rem", maxWidth: "40rem" }}>
+      <h1 style={{ fontSize: "1.25rem", marginBottom: "1rem" }}>
+        Door43 — public repo search
+      </h1>
+      <p style={{ marginBottom: "1rem", color: "#444" }}>
+        Read-only list from <code>GET /api/v1/repos/search</code> (no
+        authentication).
+      </p>
+      <ul style={{ listStyle: "disc", paddingLeft: "1.25rem" }}>
+        {repos.map((r) => (
+          <li key={r.fullName} style={{ marginBottom: "0.35rem" }}>
+            <a
+              href={r.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "inherit" }}
+            >
+              {r.fullName}
+            </a>
+          </li>
+        ))}
+      </ul>
+      <p style={{ marginTop: "1.5rem" }}>
+        <Link href="/">← Home</Link>
+      </p>
+    </main>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -36,6 +36,9 @@ export default function Home() {
             Get started by editing <code>apps/web/app/page.tsx</code>
           </li>
           <li>Save and see your changes instantly.</li>
+          <li>
+            <a href="/door43">Door43 — public repo search (M1)</a>
+          </li>
         </ol>
 
         <div className={styles.ctas}>

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  transpilePackages: ["@biblia-studio/door43"],
+  // NodeNext-style `.js` imports in `packages/door43` resolve to `.ts` sources (see `tsconfig`).
+  webpack: (config) => {
+    config.resolve.extensionAlias = {
+      ".js": [".ts", ".tsx", ".js"],
+    };
+    return config;
+  },
+};
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,14 +4,15 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3000",
-    "build": "next build",
+    "dev": "next dev --webpack --port 3000",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint --max-warnings 0",
     "check-types": "next typegen && tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@biblia-studio/door43": "*",
     "@repo/ui": "*",
     "next": "16.2.1",
     "react": "^19.2.0",

--- a/apps/web/src/adapters/driven/door43-repos.adapter.ts
+++ b/apps/web/src/adapters/driven/door43-repos.adapter.ts
@@ -1,0 +1,26 @@
+import { searchDoor43Repos } from "@biblia-studio/door43";
+import type {
+  Door43RepoListItem,
+  Door43ReposPort,
+} from "../../ports/door43-repos-port";
+
+function mapRow(row: {
+  fullName: string;
+  name: string;
+  htmlUrl: string;
+}): Door43RepoListItem {
+  return {
+    fullName: row.fullName,
+    name: row.name,
+    htmlUrl: row.htmlUrl,
+  };
+}
+
+export function createDoor43ReposAdapter(): Door43ReposPort {
+  return {
+    async searchPublicRepos({ query, limit }) {
+      const rows = await searchDoor43Repos({ query, limit });
+      return rows.map(mapRow);
+    },
+  };
+}

--- a/apps/web/src/ports/door43-repos-port.ts
+++ b/apps/web/src/ports/door43-repos-port.ts
@@ -1,0 +1,16 @@
+/**
+ * Driven port: public Door43 repo discovery (no auth).
+ * Implemented by adapters that call `@biblia-studio/door43`.
+ */
+export type Door43RepoListItem = {
+  fullName: string;
+  name: string;
+  htmlUrl: string;
+};
+
+export interface Door43ReposPort {
+  searchPublicRepos(args: {
+    query: string;
+    limit?: number;
+  }): Promise<Door43RepoListItem[]>;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@biblia-studio/door43": "*",
         "@repo/ui": "*",
         "next": "16.2.1",
         "react": "^19.2.0",

--- a/docs/02-package-map.md
+++ b/docs/02-package-map.md
@@ -6,6 +6,8 @@ Workspace packages under `@biblia-studio/*` are **intentionally bounded** by con
 
 **Apps** (`apps/*`) compose use cases with **ports and adapters** ([hexagonal architecture](./05-hexagonal-apps.md)); `@biblia-studio/*` packages often supply **driven-side** building blocks (e.g. Door43) that adapters implement behind a port.
 
+**`apps/web`** — `src/ports` holds driven **port** types (e.g. public Door43 repo search); `src/adapters/driven` implements them by calling `@biblia-studio/door43`. Route modules under `app/` stay thin and call those adapters.
+
 ## Foundation
 
 | Package                  | Folder             | Responsibility                                                                                                                                                                                                                                  |

--- a/packages/door43/README.md
+++ b/packages/door43/README.md
@@ -12,4 +12,12 @@ import { fetchDoor43Version } from "@biblia-studio/door43";
 const { version } = await fetchDoor43Version();
 ```
 
-Auth, tokens, and private resources are out of scope for this slice; see Swagger for endpoints that require login.
+**`GET /api/v1/repos/search`** — public repository search (no auth). Use `searchDoor43Repos({ query?, limit?, host? })`; the default query constant is `DOOR43_REPO_SEARCH_DEFAULT_QUERY`.
+
+```ts
+import { searchDoor43Repos } from "@biblia-studio/door43";
+
+const repos = await searchDoor43Repos({ query: "unfoldingWord", limit: 10 });
+```
+
+Auth, tokens, and private resources are out of scope for these slices; see Swagger for endpoints that require login.

--- a/packages/door43/src/index.ts
+++ b/packages/door43/src/index.ts
@@ -5,4 +5,9 @@
 export { BIBLIA_STUDIO } from "@biblia-studio/core";
 
 export { DOOR43_HOST_DEFAULT } from "./constants.js";
+export {
+  DOOR43_REPO_SEARCH_DEFAULT_QUERY,
+  searchDoor43Repos,
+  type Door43RepoSummary,
+} from "./repos-search.js";
 export { fetchDoor43Version, type Door43VersionResponse } from "./version.js";

--- a/packages/door43/src/repos-search.test.ts
+++ b/packages/door43/src/repos-search.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DOOR43_REPO_SEARCH_DEFAULT_QUERY,
+  searchDoor43Repos,
+} from "./repos-search.js";
+
+describe("searchDoor43Repos", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests /api/v1/repos/search with default query and maps repos", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        data: [
+          {
+            full_name: "org/a",
+            name: "a",
+            html_url: "https://git.door43.org/org/a",
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchDoor43Repos({ limit: 5 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://git.door43.org/api/v1/repos/search?q=${encodeURIComponent(DOOR43_REPO_SEARCH_DEFAULT_QUERY)}&limit=5`,
+      { cache: "no-store" },
+    );
+    expect(result).toEqual([
+      {
+        fullName: "org/a",
+        name: "a",
+        htmlUrl: "https://git.door43.org/org/a",
+      },
+    ]);
+  });
+
+  it("uses custom host and query", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, data: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchDoor43Repos({
+      host: "example.org",
+      query: "test",
+      limit: 10,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.org/api/v1/repos/search?q=test&limit=10",
+      { cache: "no-store" },
+    );
+  });
+
+  it("throws when response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+      }),
+    );
+
+    await expect(searchDoor43Repos()).rejects.toThrow(
+      "Door43 API 502: Bad Gateway",
+    );
+  });
+
+  it("throws when body is not a search payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: false }),
+      }),
+    );
+
+    await expect(searchDoor43Repos()).rejects.toThrow(
+      "Invalid Door43 repo search response",
+    );
+  });
+
+  it("throws when a repo row is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          data: [{ full_name: "x/y" }],
+        }),
+      }),
+    );
+
+    await expect(searchDoor43Repos()).rejects.toThrow(
+      "Invalid Door43 repo fields",
+    );
+  });
+});

--- a/packages/door43/src/repos-search.ts
+++ b/packages/door43/src/repos-search.ts
@@ -1,0 +1,53 @@
+import { DOOR43_HOST_DEFAULT } from "./constants.js";
+
+export type Door43RepoSummary = {
+  fullName: string;
+  name: string;
+  htmlUrl: string;
+};
+
+/** Default query returns stable public results on git.door43.org search. */
+export const DOOR43_REPO_SEARCH_DEFAULT_QUERY = "unfoldingWord" as const;
+
+/**
+ * Public Gitea search: `GET /api/v1/repos/search` (no auth).
+ * @see https://git.door43.org/api/swagger
+ */
+export async function searchDoor43Repos(options?: {
+  host?: string;
+  query?: string;
+  limit?: number;
+}): Promise<Door43RepoSummary[]> {
+  const host = options?.host ?? DOOR43_HOST_DEFAULT;
+  const query = options?.query ?? DOOR43_REPO_SEARCH_DEFAULT_QUERY;
+  const limit = Math.min(Math.max(options?.limit ?? 20, 1), 100);
+  const params = new URLSearchParams({ q: query, limit: String(limit) });
+  const url = `https://${host}/api/v1/repos/search?${params}`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Door43 API ${res.status}: ${res.statusText}`);
+  }
+  const body = (await res.json()) as { ok?: unknown; data?: unknown };
+  if (body.ok !== true || !Array.isArray(body.data)) {
+    throw new Error("Invalid Door43 repo search response");
+  }
+  return body.data.map(parseRepo);
+}
+
+function parseRepo(raw: unknown): Door43RepoSummary {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("Invalid repo entry in search response");
+  }
+  const o = raw as Record<string, unknown>;
+  const fullName = o.full_name;
+  const name = o.name;
+  const htmlUrl = o.html_url;
+  if (
+    typeof fullName !== "string" ||
+    typeof name !== "string" ||
+    typeof htmlUrl !== "string"
+  ) {
+    throw new Error("Invalid Door43 repo fields in search response");
+  }
+  return { fullName, name, htmlUrl };
+}


### PR DESCRIPTION
## Summary
Implements **M1** from issue #8: public `GET /api/v1/repos/search` in `@biblia-studio/door43`, hexagonal port + driven adapter in `apps/web`, and `/door43` server page.

## Notes
- **Next.js** `dev` / `build` use `--webpack` + `resolve.extensionAlias` so NodeNext `.js` imports in `packages/door43` resolve to `.ts` sources (Turbopack does not).

## Docs
- `docs/02-package-map.md`, `packages/door43/README.md`, `apps/web/README.md`

Closes #8

Made with [Cursor](https://cursor.com)